### PR TITLE
Adding the QA Questions stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import abspath, dirname, join
 
 setup(
     name="tap-nice-incontact",
-    version="0.3.4",
+    version="0.3.5",
     description="Singer.io tap for extracting data from the NICE InContact Reporting API",
     author="Stitch",
     url="http://singer.io",

--- a/tap_nice_incontact/schemas/qm_questions.json
+++ b/tap_nice_incontact/schemas/qm_questions.json
@@ -2,13 +2,16 @@
   "type": ["null", "object"],
   "additionalProperties": false,
   "properties": {
+    "workflowinstanceId": {
+      "type": ["string"]
+    },
+    "questionId": {
+      "type": ["string"]
+    },
     "actualScore": {
       "type": ["null", "number"]
     },
     "answer": {
-      "type": ["null", "string"]
-    },
-    "questionId": {
       "type": ["null", "string"]
     },
     "questionTitle": {
@@ -27,7 +30,7 @@
       "type": ["null", "string"]
     },
     "formVersion": {
-      "type": ["string"]
+      "type": ["null", "string"]
     },
     "evaluationScore%": {
       "type": ["null", "number"]
@@ -101,9 +104,6 @@
     "interactionEndDate": {
         "type": ["null", "string"],
         "format": "date-time"
-    },
-    "workflowinstanceId": {
-      "type": ["null", "string"]
     },
     "bankId": {
       "type": ["null", "string"]

--- a/tap_nice_incontact/schemas/qm_questions.json
+++ b/tap_nice_incontact/schemas/qm_questions.json
@@ -1,0 +1,112 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "actualScore": {
+      "type": ["null", "number"]
+    },
+    "answer": {
+      "type": ["null", "string"]
+    },
+    "questionId": {
+      "type": ["null", "string"]
+    },
+    "questionTitle": {
+      "type": ["null", "string"]
+    },
+    "questionNumber": {
+      "type": ["null", "string"]
+    },
+    "options": {
+      "type": ["null", "string"]
+    },
+    "formId": {
+      "type": ["null", "string"]
+    },
+    "formName": {
+      "type": ["null", "string"]
+    },
+    "formVersion": {
+      "type": ["string"]
+    },
+    "evaluationScore%": {
+      "type": ["null", "number"]
+    },
+    "evaluationStartDate": {
+        "type": ["null", "string"],
+        "format": "date-time"
+    },
+    "evaluationSubmissionDate": {
+        "type": ["null", "string"],
+        "format": "date-time"
+    },
+    "workflowType": {
+      "type": ["null", "string"]
+    },
+    "sectionId": {
+      "type": ["null", "string"]
+    },
+    "sectionTitle": {
+      "type": ["null", "string"]
+    },
+    "sectionScore%": {
+      "type": ["null", "number"]
+    },
+    "maxScore": {
+      "type": ["null", "number"]
+    },
+    "agentId": {
+      "type": ["null", "string"]
+    },
+    "firstnameAgent": {
+      "type": ["null", "string"]
+    },
+    "lastnameAgent": {
+      "type": ["null", "string"]
+    },
+    "teamId": {
+      "type": ["null", "string"]
+    },
+    "teamName": {
+      "type": ["null", "string"]
+    },
+    "firstnameEva": {
+      "type": ["null", "string"]
+    },
+    "lastnameEva": {
+      "type": ["null", "string"]
+    },
+    "critical": {
+      "type": ["null", "boolean"]
+    },
+    "failedCriticalQuestion": {
+      "type": ["null", "boolean"]
+    },
+    "mandatory": {
+      "type": ["null", "boolean"]
+    },
+    "scorable": {
+      "type": ["null", "boolean"]
+    },
+    "questionType": {
+      "type": ["null", "string"]
+    },
+    "segmentId": {
+      "type": ["null", "string"]
+    },
+    "interactionStartDate": {
+        "type": ["null", "string"],
+        "format": "date-time"
+    },
+    "interactionEndDate": {
+        "type": ["null", "string"],
+        "format": "date-time"
+    },
+    "workflowinstanceId": {
+      "type": ["null", "string"]
+    },
+    "bankId": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/tap_nice_incontact/streams.py
+++ b/tap_nice_incontact/streams.py
@@ -815,9 +815,9 @@ class QMQuestions(DataExtractionStream):
     entity_name = 'qm-questions'
     entity_version = 1
 
-    key_properties = ['evaluationSubmissionDate', 'workflowinstanceId']
+    key_properties = ['workflowinstanceId', 'questionId']
     replication_key = 'evaluationSubmissionDate'
-    valid_replication_keys = ['evaluationSubmissionDate', 'interactionStartDate']
+    valid_replication_keys = ['evaluationSubmissionDate', 'evaluationStartDate', 'interactionStartDate']
     data_key = 'qmQuestions'
 
 

--- a/tap_nice_incontact/streams.py
+++ b/tap_nice_incontact/streams.py
@@ -299,7 +299,7 @@ class SkillsSummary(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -335,7 +335,7 @@ class SkillsSLASummary(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -387,9 +387,9 @@ class TeamsPerformanceTotal(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
-            period = periods[self.tap_stream_id]    
+            period = periods[self.tap_stream_id]
 
         for start, end in self.generate_date_range(bookmark_datetime, period=period):
             params = {
@@ -483,7 +483,7 @@ class WFMSkillsAgentPerformance(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -518,7 +518,7 @@ class WFMAgents(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -588,7 +588,7 @@ class WFMAgentsScorecards(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -670,7 +670,7 @@ class DataExtractionStream(IncrementalStream):
             poll_timeout = config.get('poll_settings', {}).get('timeout')
 
         job_id = self.create_job(start_date, end_date)
-        
+
         LOGGER.info(f'Created job: {job_id}')
 
         job_details = None
@@ -718,15 +718,15 @@ class DataExtractionStream(IncrementalStream):
         :param transformer: A singer Transformer object
         :return: State data in the form of a dictionary
         """
-        
+
 
         start_date = singer.get_bookmark(state,
                                         self.tap_stream_id,
                                         self.replication_key,
                                         config['start_date'])
         bookmark_datetime = singer.utils.strptime_to_utc(start_date)
-        max_datetime = bookmark_datetime        
-        
+        max_datetime = bookmark_datetime
+
         with metrics.record_counter(self.tap_stream_id) as counter:
             for record in self.get_records(config, bookmark_datetime):
                 # Convert data keys for CSV outputs to the correct field format
@@ -757,7 +757,7 @@ class DataExtractionStream(IncrementalStream):
                     bookmark_datetime: datetime = None,
                     is_parent: bool = False) -> Iterator:
         period = self.default_period
-        periods: dict = config.get('periods') or {} 
+        periods: dict = config.get('periods') or {}
         if periods and periods.get(self.tap_stream_id):
             period = periods[self.tap_stream_id]
 
@@ -794,13 +794,31 @@ class QMWorkflows(DataExtractionStream):
     # Entity information required to create a job
     entity_name = 'qm-workflows'
     entity_version = 3
-    
+
     key_properties = ['lastUpdated', 'startDate', 'workflowId']
     replication_key = 'jobEndDate'
     valid_replication_keys = ['jobEndDate', 'lastUpdated', 'startDate']
     data_key = 'qmWorkflows'
     convert_data_types = True
     default_period = 'days'
+
+
+class QMQuestions(DataExtractionStream):
+    """
+    Retrieve QM Questions via the data extraction api.
+
+    Docs: https://help.nice-incontact.com/content/recording/dataextractionapi.htm#QMQuestionsandAnswersQAEntityandCSVFile
+    """
+    tap_stream_id = 'qm_questions'
+
+    # Entity information required to create a job
+    entity_name = 'qm-questions'
+    entity_version = 1
+
+    key_properties = ['evaluationSubmissionDate', 'workflowinstanceId']
+    replication_key = 'evaluationSubmissionDate'
+    valid_replication_keys = ['evaluationSubmissionDate', 'interactionStartDate']
+    data_key = 'qmQuestions'
 
 
 STREAMS = {
@@ -815,5 +833,6 @@ STREAMS = {
     'wfm_agents': WFMAgents,
     'wfm_agents_schedule_adherence': WFMAgentsScheduleAdherence,
     'wfm_agents_scorecards': WFMAgentsScorecards,
-    'qm_workflows': QMWorkflows
+    'qm_workflows': QMWorkflows,
+    'qm_questions': QMQuestions,
 }


### PR DESCRIPTION
# Description of change
This change introduces a new stream for [QM Questions and Answers (Q&A) Entity](https://help.nice-incontact.com/content/recording/dataextractionapi.htm#QMQuestionsandAnswersQAEntityandCSVFile) data that utilizes the  recently added `DataExtractionStream` stream base class. 

# Manual QA steps
 - Run `tap-nice-incontact --discover -c config.json > catalog.json`
 - Add `"selected": true` to the `qm_questions` stream
 - Run `tap-nice-incontact -c config.json --catalog catalog.json`
